### PR TITLE
Cambiado librerías por bibliotecas

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -5,7 +5,7 @@
       <p>¡Te damos la bienvenida a <b>AlmeríaJS</b>!</p>
       <p>
         Somos un grupo de apasionados de la tecnología que nos juntamos (física o virtualmente) cada vez que tenemos
-        ocasión para hablar de cualquier tema relacionado con Javascript, frameworks, librerías, cualquier tipo de
+        ocasión para hablar de cualquier tema relacionado con Javascript, frameworks, bibliotecas, cualquier tipo de
         herramienta o incluso servicios para explotar nuestas aplicaiones web.
       </p>
       <p>Solemos terminar con lo que más nos gusta, networking con 🍻</p>


### PR DESCRIPTION
Aunque coloquialmente se acepta, el término correcto sigue siendo biblioteca.

PD: Que por saco doy...